### PR TITLE
UX: custom menus and style updates

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -7,7 +7,9 @@
 #sidebar-section-content-community,
 [data-section-name="categories"],
 [data-section-name="messages"],
-.sidebar-section-link .sidebar-section-link-prefix,
+.sidebar-sections:not(.admin-panel)
+  .sidebar-section-link
+  .sidebar-section-link-prefix,
 .sidebar-footer-wrapper {
   display: none;
 }
@@ -69,15 +71,16 @@
 // topic elements
 
 #topic-footer-button-share-and-invite,
-#topic-footer-button-archive,
-.topic-notifications-button,
+body:not(.staff) #topic-footer-button-archive,
+#topic-footer-buttons .topic-notifications-button,
 .bookmark-menu-trigger,
 .more-topics__container,
 .private-message-glyph-wrapper,
 .topic-header-participants,
 .topic-above-footer-buttons-outlet,
 .topic-map,
-.timeline-ago {
+.timeline-ago,
+#topic-footer-buttons .topic-footer-main-buttons details {
   display: none;
 }
 
@@ -95,18 +98,81 @@
   .topic-navigation.with-timeline {
     top: calc(var(--header-offset, 60px) + 5.5em);
   }
+
+  .topic-navigation {
+    .topic-notifications-button {
+      display: none;
+    }
+  }
+}
+
+#topic-title {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+
+  .title-wrapper {
+    width: 100%;
+    max-width: 960px;
+  }
+}
+
+.small-action,
+.onscreen-post .row {
+  justify-content: center;
 }
 
 #topic-footer-buttons {
+  width: calc(100% - 6.5em);
+  @media screen and (max-width: 924px) {
+    max-width: unset;
+    width: 100%;
+  }
+  @media screen and (min-width: 1300px) {
+    width: 100%;
+    max-width: 51em;
+  }
   margin-top: 0;
   .topic-footer-main-buttons {
-    flex-direction: row-reverse;
     justify-content: flex-end;
+    @media screen and (min-width: 1180px) {
+      margin-right: 0.6em;
+    }
+    @media screen and (max-width: 924px) {
+      margin-right: 0.6em;
+    }
+  }
+}
+
+#topic-progress-wrapper.docked {
+  display: none;
+}
+
+@media screen and (max-width: 924px) {
+  .archetype-private_message .topic-post:last-child {
+    margin-bottom: 0;
+  }
+}
+
+nav.post-controls .actions button {
+  padding: 0.5em 0.65em;
+  &.reply {
+    .d-icon {
+      margin-right: 0.45em;
+    }
   }
 }
 
 .topic-footer-main-buttons {
   margin-left: calc(var(--topic-avatar-width) - 1.15em);
+}
+
+// hide header user button
+
+.d-header {
+  #current-user {
+    display: none;
+  }
 }
 
 // header bot button
@@ -128,6 +194,16 @@ html.composer-open .custom-homepage #main-outlet {
 }
 
 .custom-homepage {
+  @media screen and (max-width: 676px) {
+    #main-outlet {
+      padding-top: 0;
+    }
+    #main-outlet-wrapper #main-outlet {
+      max-width: 95vw;
+      overflow-x: hidden;
+    }
+  }
+
   // hide toggle until we know there are messages
   &:not(.sidebar-animate) {
     &.has-sidebar-page .header-sidebar-toggle {
@@ -149,8 +225,10 @@ html.composer-open .custom-homepage #main-outlet {
     .sidebar-wrapper {
       display: none;
     }
-    .custom-homepage__content-wrapper {
-      margin-left: 1em;
+    @media screen and (min-width: 900px) {
+      .custom-homepage__content-wrapper {
+        margin-left: 1em;
+      }
     }
   }
 
@@ -176,19 +254,26 @@ html.composer-open .custom-homepage #main-outlet {
     box-sizing: border-box;
     align-items: center;
     justify-content: center;
-    border: 1px solid var(--primary-low);
-    padding: 2em 2em 3em;
-    border-radius: var(--border-radius);
-    height: calc(100dvh - var(--header-offset) - 4em);
+    height: calc(100dvh - var(--header-offset) - 1.25em);
+    @media screen and (min-width: 675px) {
+      border: 1px solid var(--primary-low);
+      padding: 2em 2em 3em;
+      border-radius: var(--border-radius);
+      height: calc(100dvh - var(--header-offset) - 4em);
+    }
   }
 
   &__input-wrapper {
     display: flex;
     align-items: stretch;
     gap: 0.5em;
-    width: 80%;
-    max-width: 46em;
+    width: 100%;
+    max-width: 90dvw;
     margin-top: 2em;
+    @media screen and (min-width: 600px) {
+      width: 80%;
+      max-width: 46em;
+    }
 
     input {
       width: 100%;
@@ -200,6 +285,36 @@ html.composer-open .custom-homepage #main-outlet {
     margin-bottom: 1em;
     display: flex;
     gap: 1em;
+    @media screen and (max-width: 600px) {
+      padding-right: 2em;
+      box-sizing: border-box;
+      max-width: 95dvw;
+      min-width: 0;
+      overflow: auto;
+      font-size: var(--font-down-1);
+      padding-bottom: 0.5em;
+      margin-bottom: 0.5em;
+      &:after {
+        position: absolute;
+        content: "";
+        width: 4em;
+        background: linear-gradient(
+          to right,
+          rgba(var(--secondary-rgb), 0),
+          rgba(var(--secondary-rgb), 1)
+        );
+        right: 0;
+        height: 2.5em;
+        z-index: 2;
+      }
+
+      button {
+        display: flex;
+        .d-button-label {
+          white-space: nowrap;
+        }
+      }
+    }
   }
 
   h1 {
@@ -226,14 +341,31 @@ html.composer-open .custom-homepage #main-outlet {
     .d-button-label {
       color: var(--primary-high);
     }
+    .discourse-no-touch & {
+      &:hover {
+        background: var(--primary-low);
+      }
+    }
   }
 
   .ai-disclaimer {
-    width: 80%;
-    max-width: 46em;
     text-align: center;
     font-size: var(--font-down-1);
     color: var(--primary-700);
+    @media screen and (min-width: 600px) {
+      width: 80%;
+      max-width: 46em;
+    }
+  }
+
+  .sidebar-footer-wrapper {
+    display: flex;
+    .powered-by-discourse {
+      display: block;
+    }
+    button {
+      display: none;
+    }
   }
 }
 
@@ -258,4 +390,110 @@ html.composer-open .custom-homepage #main-outlet {
 
 .user-content {
   margin-top: 0;
+}
+
+// custom header menus
+
+.custom-admin-menu-trigger {
+  position: relative;
+  &.-has-messages {
+    &:after {
+      position: absolute;
+      content: "";
+      background: var(--danger);
+      border-radius: 100%;
+      padding: 0.25em;
+      top: 0.5em;
+      right: 0.25em;
+    }
+  }
+}
+
+.custom-admin-menu-trigger {
+  background: transparent;
+}
+
+.custom-menu {
+  .mod-message-badge {
+    padding: 0.25em;
+    background: var(--danger);
+    border-radius: 100%;
+    font-size: var(--font-down-3);
+  }
+
+  &[class*="__links"] {
+    margin: 0;
+    list-style-type: none;
+    display: flex;
+    flex-direction: column;
+    padding: 0.75em;
+    gap: 0.25em;
+
+    li {
+      .discourse-no-touch & {
+        &:hover {
+          background: var(--d-hover);
+        }
+      }
+    }
+
+    .btn,
+    a {
+      box-sizing: border-box;
+      display: inline-flex;
+      justify-content: start;
+      gap: 0.5em;
+      width: 100%;
+      color: var(--primary);
+      padding: 0.25em 0.5em;
+      line-height: var(--line-height-large);
+
+      .d-icon {
+        color: var(--primary-high);
+      }
+      span {
+        display: flex;
+        gap: 0.5em;
+        align-items: center;
+      }
+    }
+  }
+}
+
+// user prefs
+
+.user-preferences-page {
+  .d-header-icons .header-dropdown-toggle.search-dropdown {
+    display: none;
+  }
+
+  .control-group.home,
+  .control-group.other {
+    display: none;
+  }
+}
+
+// small screens
+
+@media screen and (max-width: 600px) {
+  .share-ai-conversation-button {
+    .d-icon {
+      margin: 0;
+    }
+    .d-button-label {
+      display: none;
+    }
+  }
+}
+
+.mobile-view {
+  nav.post-controls .actions button.reply .d-icon {
+    margin: 0;
+  }
+  .search-dropdown {
+    display: none;
+  }
+  .sidebar-custom-sections {
+    display: none;
+  }
 }

--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -52,7 +52,7 @@ export default class CustomAdminMenu extends Component {
               </LinkTo>
             </li>
             <li>
-              <LinkTo @route="group.messages.inbox" @model={{"moderators"}}>
+              <LinkTo @route="group.messages.inbox" @model="moderators">
                 <span>
                   {{icon "shield-alt"}}
                   {{i18n (themePrefix "admin_menu.mod_messages")}}

--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -25,7 +25,7 @@ export default class CustomAdminMenu extends Component {
 
   get modHasMessages() {
     this.pmTopicTrackingState.activeGroup = "moderators";
-    return this.pmTopicTrackingState?.newIncoming?.length;
+    return this.pmTopicTrackingState.newIncoming?.length;
   }
 
   <template>

--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -1,0 +1,87 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
+import icon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
+import DMenu from "float-kit/components/d-menu";
+
+export default class CustomAdminMenu extends Component {
+  @service currentUser;
+  @service store;
+  @service pmTopicTrackingState;
+
+  @tracked botUser = null;
+
+  constructor() {
+    super(...arguments);
+    this.loadBotUser();
+  }
+
+  async loadBotUser() {
+    this.botUser = await this.store.find("user", "gpt-4o");
+  }
+
+  get modHasMessages() {
+    this.pmTopicTrackingState.activeGroup = "moderators";
+    return this.pmTopicTrackingState?.newIncoming?.length;
+  }
+
+  <template>
+    <li class="custom-admin-menu">
+      <DMenu
+        @icon="cog"
+        @placement="bottom-end"
+        @identifier="custom-admin-menu"
+        @triggerClass="icon btn-flat {{if this.modHasMessages '-has-messages'}}"
+        @groupIdentifier="custom-header"
+      >
+        <:content as |args|>
+          {{! template-lint-disable no-invalid-interactive }}
+          <ul
+            class="custom-admin-menu__links custom-menu"
+            {{on "click" args.close}}
+          >
+            <li>
+              <LinkTo @route="admin">
+                <span>
+                  {{icon "wrench"}}
+                  {{i18n "sidebar.sections.community.links.admin.content"}}
+                </span>
+              </LinkTo>
+            </li>
+            <li>
+              <LinkTo @route="group.messages.inbox" @model={{"moderators"}}>
+                <span>
+                  {{icon "shield-alt"}}
+                  {{i18n (themePrefix "admin_menu.mod_messages")}}
+                  {{#if this.modHasMessages}}
+                    <span class="mod-message-badge"></span>
+                  {{/if}}
+                </span>
+              </LinkTo>
+            </li>
+            <li>
+              <LinkTo @route="userPrivateMessages" @model={{this.botUser}}>
+                <span>
+                  {{icon "envelope"}}
+                  {{i18n (themePrefix "admin_menu.all_messages")}}
+                </span>
+              </LinkTo>
+            </li>
+            <li>
+              <a href="/admin/plugins/discourse-ai/ai-llms">
+                <span>
+                  {{icon "discourse-sparkles"}}{{i18n
+                    (themePrefix "admin_menu.ai_config")
+                  }}
+                </span>
+              </a>
+            </li>
+          </ul>
+        </:content>
+      </DMenu>
+    </li>
+  </template>
+}

--- a/javascripts/discourse/components/custom-user-menu.gjs
+++ b/javascripts/discourse/components/custom-user-menu.gjs
@@ -1,0 +1,84 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import avatar from "discourse/helpers/bound-avatar-template";
+import routeAction from "discourse/helpers/route-action";
+import icon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
+import DMenu from "float-kit/components/d-menu";
+
+export default class CustomUserMenu extends Component {
+  @service currentUser;
+
+  <template>
+    <li class="custom-user-menu">
+      <DMenu
+        @placement="bottom-end"
+        @identifier="custom-user-menu"
+        @triggerClass="icon btn-flat"
+        @groupIdentifier="custom-header"
+      >
+        <:trigger>
+          {{avatar this.currentUser.avatar_template "medium"}}
+        </:trigger>
+
+        <:content as |args|>
+          {{! template-lint-disable no-invalid-interactive }}
+          <ul
+            class="custom-user-menu__links custom-menu"
+            {{on "click" args.close}}
+          >
+            <li>
+              <LinkTo @route="userPrivateMessages" @model={{this.currentUser}}>
+                <span>{{icon "envelope"}}{{i18n
+                    (themePrefix "user_menu.all_questions")
+                  }}</span>
+              </LinkTo>
+            </li>
+            <li>
+              <a
+                href="https://meta.discourse.org/t/help-us-test-ask-discourse-com/324441"
+              >
+                <span>
+                  {{icon "fab-discourse"}}{{i18n
+                    (themePrefix "user_menu.feedback")
+                  }}
+                </span>
+              </a>
+            </li>
+            <li>
+              <LinkTo
+                @route="preferences.interface"
+                @model={{this.currentUser}}
+              >
+                <span>{{icon "palette"}}{{i18n
+                    (themePrefix "user_menu.appearance")
+                  }}</span>
+              </LinkTo>
+            </li>
+            <li>
+              <LinkTo @route="preferences.account" @model={{this.currentUser}}>
+                <span>{{icon "user"}}{{i18n
+                    (themePrefix "user_menu.account")
+                  }}</span>
+              </LinkTo>
+            </li>
+            <li>
+              <DButton
+                @action={{routeAction "logout"}}
+                class="btn-flat profile-tab-btn"
+              >
+                {{icon "sign-out-alt"}}
+                <span class="item-label">
+                  {{i18n "user.log_out"}}
+                </span>
+              </DButton>
+            </li>
+          </ul>
+        </:content>
+      </DMenu>
+    </li>
+  </template>
+}

--- a/javascripts/discourse/components/sidebar-new-message.gjs
+++ b/javascripts/discourse/components/sidebar-new-message.gjs
@@ -1,34 +1,13 @@
-import Component from "@glimmer/component";
-import { action } from "@ember/object";
-import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
-import Composer from "discourse/models/composer";
 import i18n from "discourse-common/helpers/i18n";
-import I18n from "discourse-i18n";
 
-export default class SidebarNewMessage extends Component {
-  @service composer;
+const SidebarNewMessage = <template>
+  <DButton
+    @route="/"
+    @translatedLabel={{i18n (themePrefix "new_question")}}
+    @icon="plus"
+    class="ai-new-question-button btn-default"
+  />
+</template>;
 
-  inputValue = "";
-
-  @action
-  async openComposer() {
-    await this.composer.open({
-      action: Composer.PRIVATE_MESSAGE,
-      draftKey: "private_message_ai",
-      recipients: "gpt-4o",
-      topicTitle: I18n.t("discourse_ai.ai_bot.default_pm_prefix"),
-      archetypeId: "private_message",
-      disableDrafts: true,
-    });
-  }
-
-  <template>
-    <DButton
-      @action={{this.openComposer}}
-      @translatedLabel={{i18n (themePrefix "new_question")}}
-      @icon="plus"
-      class="ai-new-question-button btn-default"
-    />
-  </template>
-}
+export default SidebarNewMessage;

--- a/javascripts/discourse/initializers/init-custom-pm-sidebar.js
+++ b/javascripts/discourse/initializers/init-custom-pm-sidebar.js
@@ -6,7 +6,7 @@ import I18n from "discourse-i18n";
 export default {
   name: "custom-sidebar-bot-messages",
   initialize() {
-    withPluginApi("1.3.0", (api) => {
+    withPluginApi("1.37.1", (api) => {
       const currentUser = api.container.lookup("service:current-user");
       const appEvents = api.container.lookup("service:app-events");
       const messageBus = api.container.lookup("service:message-bus");

--- a/javascripts/discourse/initializers/init-header-admin-menu.js
+++ b/javascripts/discourse/initializers/init-header-admin-menu.js
@@ -1,0 +1,12 @@
+import { apiInitializer } from "discourse/lib/api";
+import CustomAdminMenu from "../components/custom-admin-menu";
+
+export default apiInitializer("1.0", (api) => {
+  const currentUser = api.getCurrentUser();
+
+  if (currentUser.admin) {
+    api.headerIcons.add("custom-admin-menu", CustomAdminMenu, {
+      after: "search",
+    });
+  }
+});

--- a/javascripts/discourse/initializers/init-header-user-menu.js
+++ b/javascripts/discourse/initializers/init-header-user-menu.js
@@ -1,0 +1,12 @@
+import { apiInitializer } from "discourse/lib/api";
+import CustomUserMenu from "../components/custom-user-menu";
+
+export default apiInitializer("1.0", (api) => {
+  const currentUser = api.getCurrentUser();
+
+  if (currentUser) {
+    api.headerIcons.add("custom-user-menu", CustomUserMenu, {
+      after: "search",
+    });
+  }
+});

--- a/javascripts/discourse/initializers/init-powered-by-sidebar-footer.js
+++ b/javascripts/discourse/initializers/init-powered-by-sidebar-footer.js
@@ -1,0 +1,6 @@
+import PoweredByDiscourse from "discourse/components/powered-by-discourse";
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("1.8.0", (api) => {
+  api.renderInOutlet("sidebar-footer-actions", PoweredByDiscourse);
+});

--- a/javascripts/discourse/initializers/init-replace-icons.js
+++ b/javascripts/discourse/initializers/init-replace-icons.js
@@ -1,0 +1,12 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "custom-icons",
+  initialize() {
+    withPluginApi("0.8.31", (api) => {
+      api.replaceIcon("flag", "far-thumbs-down");
+      api.replaceIcon("d-unliked", "far-thumbs-up");
+      api.replaceIcon("d-liked", "thumbs-up");
+    });
+  },
+};

--- a/javascripts/discourse/initializers/init-replace-icons.js
+++ b/javascripts/discourse/initializers/init-replace-icons.js
@@ -3,7 +3,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 export default {
   name: "custom-icons",
   initialize() {
-    withPluginApi("0.8.31", (api) => {
+    withPluginApi("1.37.1", (api) => {
       api.replaceIcon("flag", "far-thumbs-down");
       api.replaceIcon("d-unliked", "far-thumbs-up");
       api.replaceIcon("d-liked", "thumbs-up");

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,3 +14,12 @@ en:
     engine. All content on this site is reviewed regularly by Discourse
     staff."
   new_question: "New Question"
+  admin_menu:
+    all_messages: "All Bot Messages"
+    ai_config: "AI Configuration"
+    mod_messages: "Moderation Inbox"
+  user_menu:
+    feedback: "Support & Feedback"
+    all_questions: "All Questions"
+    appearance: "Fonts & Appearance"
+    account: "Account Settings"


### PR DESCRIPTION
This includes a bunch of changes, including:

* Custom header menus for admins and normal users 

  ![image](https://github.com/user-attachments/assets/b0c01786-1cde-46c9-a140-6369e366f464)
   
  ![image](https://github.com/user-attachments/assets/c0d0aafa-f2c3-488f-9d5c-fa2dba83eb56)


* Powered by Discourse in the homepage sidebar footer

   
  ![image](https://github.com/user-attachments/assets/070b76bc-8e11-47a5-a291-54b90cb5f08b)


* Replacing like and flag icon with thumbs up/down 

   
  ![image](https://github.com/user-attachments/assets/0efead9a-39cb-4ca8-ac8c-8e2b590483e3)


* General style adjustments 