### PR TITLE
UX: add Meta link to user card

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -497,3 +497,14 @@ html.composer-open .custom-homepage #main-outlet {
     display: none;
   }
 }
+
+// custom user card link
+
+.user-card-meta__profile-link {
+  display: block;
+  padding: 0.5em 0 0.25em;
+  .d-icon {
+    font-size: var(--font-down-1);
+    margin-right: 0.15em;
+  }
+}

--- a/javascripts/discourse/components/user-card-meta-data.gjs
+++ b/javascripts/discourse/components/user-card-meta-data.gjs
@@ -11,6 +11,7 @@ export default class UserCardMetaData extends Component {
       <a
         href="https://meta.discourse.org/u/{{@outletArgs.user.username_lower}}"
         target="_blank"
+        rel="noopener noreferrer"
         class="user-card-meta__profile-link"
       >
         {{icon "up-right-from-square"}}

--- a/javascripts/discourse/components/user-card-meta-data.gjs
+++ b/javascripts/discourse/components/user-card-meta-data.gjs
@@ -1,0 +1,22 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import icon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
+
+export default class UserCardMetaData extends Component {
+  @service currentUser;
+
+  <template>
+    {{#if this.currentUser.admin}}
+      <a
+        href="https://meta.discourse.org/u/{{@outletArgs.user.username_lower}}"
+        target="_blank"
+        class="user-card-meta__profile-link"
+      >
+        {{icon "up-right-from-square"}}
+        {{@outletArgs.user.username}}
+        {{i18n (themePrefix "meta.profile_link")}}
+      </a>
+    {{/if}}
+  </template>
+}

--- a/javascripts/discourse/initializers/init-user-card-extras.js
+++ b/javascripts/discourse/initializers/init-user-card-extras.js
@@ -1,0 +1,6 @@
+import { apiInitializer } from "discourse/lib/api";
+import UserCardMetaData from "../components/user-card-meta-data";
+
+export default apiInitializer("1.8.0", (api) => {
+  api.renderInOutlet("user-card-before-badges", UserCardMetaData);
+});

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,3 +23,5 @@ en:
     all_questions: "All Questions"
     appearance: "Fonts & Appearance"
     account: "Account Settings"
+  meta:
+    profile_link: "on Meta"


### PR DESCRIPTION
Adds a quick link to the user's profile from their usercard 

![image](https://github.com/user-attachments/assets/6e9c8fe5-923d-4222-bb54-6681e3701610)
