### PR TITLE
UX: add link to liked messages for admins

### DIFF
--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -52,9 +52,17 @@ export default class CustomAdminMenu extends Component {
               </LinkTo>
             </li>
             <li>
+              <a href="/admin/plugins/explorer?id=4&params=null">
+                <span>
+                  {{icon "thumbs-up"}}
+                  {{i18n (themePrefix "admin_menu.liked_messages")}}
+                </span>
+              </a>
+            </li>
+            <li>
               <LinkTo @route="group.messages.inbox" @model="moderators">
                 <span>
-                  {{icon "shield-alt"}}
+                  {{icon "thumbs-down"}}
                   {{i18n (themePrefix "admin_menu.mod_messages")}}
                   {{#if this.modHasMessages}}
                     <span class="mod-message-badge"></span>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -18,6 +18,7 @@ en:
     all_messages: "All Bot Messages"
     ai_config: "AI Configuration"
     mod_messages: "Moderation Inbox"
+    liked_messages: "Liked Messages"
   user_menu:
     feedback: "Support & Feedback"
     all_questions: "All Questions"


### PR DESCRIPTION
Adds "liked messages" link to data explorer query 

![image](https://github.com/user-attachments/assets/2e57915c-bf52-4111-9913-24c50707183a)
