### PR TITLE
UX: automatic multi-line textarea on homepage

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -275,9 +275,14 @@ html.composer-open .custom-homepage #main-outlet {
       max-width: 46em;
     }
 
-    input {
+    .btn-primary {
+      align-self: end;
+    }
+
+    #custom-homepage-input {
       width: 100%;
       margin: 0;
+      min-height: 2.33em;
     }
   }
 

--- a/javascripts/discourse/components/custom-homepage.gjs
+++ b/javascripts/discourse/components/custom-homepage.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { Input } from "@ember/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -8,9 +7,12 @@ import DButton from "discourse/components/d-button";
 import bodyClass from "discourse/helpers/body-class";
 import i18n from "discourse-common/helpers/i18n";
 import HomepageButtons from "../components/homepage-buttons";
+import SimpleTextareaInteractor from "../lib/simple-textarea-interactor";
 
 export default class CustomHomepage extends Component {
   @service hiddenSubmit;
+
+  textareaInteractor = null;
 
   @action
   updateInputValue(event) {
@@ -19,9 +21,14 @@ export default class CustomHomepage extends Component {
 
   @action
   handleKeyDown(event) {
-    if (event.key === "Enter") {
+    if (event.key === "Enter" && !event.shiftKey) {
       this.hiddenSubmit.submitToBot();
     }
+  }
+
+  @action
+  initializeTextarea(element) {
+    this.textareaInteractor = new SimpleTextareaInteractor(element);
   }
 
   <template>
@@ -30,14 +37,14 @@ export default class CustomHomepage extends Component {
       <h1>{{i18n (themePrefix "title")}}</h1>
       <HomepageButtons />
       <div class="custom-homepage__input-wrapper">
-        <Input
-          {{didInsert this.hiddenSubmit.focusInput}}
+        <textarea
+          {{didInsert this.initializeTextarea}}
           {{on "input" this.updateInputValue}}
           {{on "keydown" this.handleKeyDown}}
-          @type="text"
           id="custom-homepage-input"
           placeholder={{i18n (themePrefix "input_placeholder")}}
           minlength="10"
+          rows="1"
         />
         <DButton
           @action={{this.hiddenSubmit.submitToBot}}

--- a/javascripts/discourse/lib/simple-textarea-interactor.js
+++ b/javascripts/discourse/lib/simple-textarea-interactor.js
@@ -1,0 +1,29 @@
+import { schedule } from "@ember/runloop";
+
+export default class SimpleTextareaInteractor {
+  // lifted from "discourse/plugins/chat/discourse/lib/textarea-interactor"
+  // because the chat plugin isn't active on this site
+  constructor(textarea) {
+    this.textarea = textarea;
+    this.init();
+    this.refreshHeightBound = this.refreshHeight.bind(this);
+    this.textarea.addEventListener("input", this.refreshHeightBound);
+  }
+
+  init() {
+    schedule("afterRender", () => {
+      this.refreshHeight();
+    });
+  }
+
+  teardown() {
+    this.textarea.removeEventListener("input", this.refreshHeightBound);
+  }
+
+  refreshHeight() {
+    schedule("afterRender", () => {
+      this.textarea.style.height = "auto";
+      this.textarea.style.height = `${this.textarea.scrollHeight + 1}px`;
+    });
+  }
+}


### PR DESCRIPTION
This copies a method used in core here: https://github.com/discourse/discourse/blob/038e5deb2a19fb6e2ca0317100525713692f7696/plugins/chat/assets/javascripts/discourse/lib/textarea-interactor.js

To get a resizable textarea on the homepage:

![image](https://github.com/user-attachments/assets/6500f3a4-82e8-4dc8-ae8b-f47afbc4dfbc)

It would be nice to reuse the core code, but the chat plugin isn't enabled on this site 

