### PR TITLE
UX: remove homepage textarea resize, height & focus tweaks

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -277,12 +277,18 @@ html.composer-open .custom-homepage #main-outlet {
 
     .btn-primary {
       align-self: end;
+      min-height: 2.5em;
     }
 
     #custom-homepage-input {
       width: 100%;
       margin: 0;
-      min-height: 2.33em;
+      resize: none;
+      border-radius: var(--d-button-border-radius);
+      &:focus {
+        outline: none;
+        border-color: var(--primary-high);
+      }
     }
   }
 

--- a/javascripts/discourse/lib/simple-textarea-interactor.js
+++ b/javascripts/discourse/lib/simple-textarea-interactor.js
@@ -23,7 +23,7 @@ export default class SimpleTextareaInteractor {
   refreshHeight() {
     schedule("afterRender", () => {
       this.textarea.style.height = "auto";
-      this.textarea.style.height = `${this.textarea.scrollHeight + 1}px`;
+      this.textarea.style.height = `${this.textarea.scrollHeight + 2}px`;
     });
   }
 }


### PR DESCRIPTION
This makes the focus state more subtle, rounds the textarea border slightly, removes the manual resizing of the textarea, and adjusts the height slightly to avoid an occasional scrollbar 

Before:

![image](https://github.com/user-attachments/assets/06a7e28d-f14d-4012-83e4-2b2a14eaa869)


After:

![image](https://github.com/user-attachments/assets/c4c7f5b4-7280-471f-8a5d-9b3e960eb65c)
