### PR TITLE
UX: limit height of homepage textarea, fix double submit bug

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -285,6 +285,7 @@ html.composer-open .custom-homepage #main-outlet {
       margin: 0;
       resize: none;
       border-radius: var(--d-button-border-radius);
+      max-height: 30vh;
       &:focus {
         outline: none;
         border-color: var(--primary-high);

--- a/javascripts/discourse/services/hidden-submit.js
+++ b/javascripts/discourse/services/hidden-submit.js
@@ -45,6 +45,11 @@ export default class HiddenSubmit extends Service {
 
     try {
       await this.composer.save();
+      if (this.inputValue.length > 10) {
+        // prevents submitting same message again when returning home
+        // but avoids deleting too-short message on submit
+        this.inputValue = "";
+      }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error("Failed to submit message:", error);


### PR DESCRIPTION
Addresses the issues here: https://meta.discourse.org/t/help-us-test-ask-discourse-com/324441/16?u=awesomerobot

1. The homepage textarea can become too large, so I put a max-height on it
2. After submitting a question and returning to the homepage, the textarea appears blank but if you submit it in this state you'll submit your last query behind the scenes. This update wipes the `inputValue` if it's long enough to be submitted. We don't want to wipe the input if it's too short for submission, because we want people to have a chance to add more characters. 