### PR TITLE
FIX: change messages to route to dedicated user

### DIFF
--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";

--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -19,10 +19,6 @@ export default class CustomAdminMenu extends Component {
     this.loadBotUser();
   }
 
-  async loadBotUser() {
-    this.botUser = await this.store.find("user", "gpt-4o");
-  }
-
   get modHasMessages() {
     this.pmTopicTrackingState.activeGroup = "moderators";
     return this.pmTopicTrackingState.newIncoming?.length;
@@ -71,12 +67,12 @@ export default class CustomAdminMenu extends Component {
               </LinkTo>
             </li>
             <li>
-              <LinkTo @route="userPrivateMessages" @model={{this.botUser}}>
+              <a href="/u/discoursehelper/messages">
                 <span>
                   {{icon "envelope"}}
                   {{i18n (themePrefix "admin_menu.all_messages")}}
                 </span>
-              </LinkTo>
+              </a>
             </li>
             <li>
               <a href="/admin/plugins/discourse-ai/ai-llms">

--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -9,14 +9,10 @@ import DMenu from "float-kit/components/d-menu";
 
 export default class CustomAdminMenu extends Component {
   @service currentUser;
-  @service store;
   @service pmTopicTrackingState;
-
-  @tracked botUser = null;
 
   constructor() {
     super(...arguments);
-    this.loadBotUser();
   }
 
   get modHasMessages() {

--- a/javascripts/discourse/services/hidden-submit.js
+++ b/javascripts/discourse/services/hidden-submit.js
@@ -36,7 +36,7 @@ export default class HiddenSubmit extends Service {
     await this.composer.open({
       action: Composer.PRIVATE_MESSAGE,
       draftKey: "private_message_ai",
-      recipients: "gpt-4o",
+      recipients: "DiscourseHelper",
       topicTitle: I18n.t("discourse_ai.ai_bot.default_pm_prefix"),
       topicBody: this.inputValue,
       archetypeId: "private_message",


### PR DESCRIPTION
Discourse Helper now has a dedicated user, this avoids the indirection
of sending messages to gpt-4o just to be redirected to the user.
