### PR TITLE
UX: show notification menu

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -167,12 +167,21 @@ nav.post-controls .actions button {
   margin-left: calc(var(--topic-avatar-width) - 1.15em);
 }
 
-// hide header user button
+// custom header notification button
 
-.d-header {
-  #current-user {
+.user-menu.revamped .menu-tabs-container {
+  display: none;
+}
+
+#toggle-current-user {
+  order: 2;
+  img.avatar {
     display: none;
   }
+}
+
+.custom-user-menu {
+  order: 3;
 }
 
 // header bot button

--- a/javascripts/discourse/initializers/init-custom-notification-icon.gjs
+++ b/javascripts/discourse/initializers/init-custom-notification-icon.gjs
@@ -1,0 +1,8 @@
+import { apiInitializer } from "discourse/lib/api";
+import icon from "discourse-common/helpers/d-icon";
+
+export default apiInitializer("1.8.0", (api) => {
+  api.renderInOutlet("user-dropdown-notifications__before", <template>
+    {{icon "bell"}}
+  </template>);
+});


### PR DESCRIPTION
This shows a simplified notification menu, previously notifications were entirely inaccessible 

Before:
![image](https://github.com/user-attachments/assets/852d2784-9e9c-4095-bc9a-a4a0d5df7b2e)


After:
![image](https://github.com/user-attachments/assets/f061e346-8ae5-4c5f-88ce-0eab64a49fc1)
