### PR TITLE
UX: update feedback link

### DIFF
--- a/javascripts/discourse/components/custom-user-menu.gjs
+++ b/javascripts/discourse/components/custom-user-menu.gjs
@@ -39,7 +39,7 @@ export default class CustomUserMenu extends Component {
             </li>
             <li>
               <a
-                href="https://meta.discourse.org/t/help-us-test-ask-discourse-com/324441"
+                href="https://meta.discourse.org/t/feedback-for-ask-discourse-via-chat/336805"
               >
                 <span>
                   {{icon "fab-discourse"}}{{i18n


### PR DESCRIPTION
The previous link was to the lounge category, which isn't available for everyone. 

Now that more people have access, we should link to a more public topic. 