### PR TITLE
DEV: use modifyClass for homepage behavior instead of setDefaultHomepage

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -303,3 +303,14 @@ html.composer-open .custom-homepage #main-outlet {
 .sidebar-row {
   --d-sidebar-row-horizontal-padding: 0.33em;
 }
+
+// Hide "back to forum" because we're only focusing on AI conversations
+.sidebar-wrapper .sidebar-sections__back-to-forum {
+  display: none;
+}
+
+body.has-ai-conversations-sidebar
+  .sidebar-sections__back-to-forum
+  + .ai-new-question-button__wrapper {
+  margin-top: var(--space-6);
+}

--- a/javascripts/discourse/initializers/init-force-homepage.js
+++ b/javascripts/discourse/initializers/init-force-homepage.js
@@ -1,22 +1,21 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { setDefaultHomepage } from "discourse/lib/utilities";
 
 export default {
   name: "discourse-custom-homepage",
   initialize() {
     withPluginApi((api) => {
-      const user = api.getCurrentUser();
-      const aiBotinHeader = api.container.lookup(
-        "service:site-settings"
-      )?.ai_bot_add_to_header;
-
-      // we can get stuck in a circular reference
-      // if the bot header button is enabled
-      // due to its fallback for lastKnownAppURL
-      // the button should be disabled
-      // but this check will prevent a crash
-      if (!aiBotinHeader && user) {
-        setDefaultHomepage("discourse-ai/ai-bot/conversations");
+      if (api.getCurrentUser()) {
+        api.modifyClass(
+          "route:discovery.index",
+          (Superclass) =>
+            class extends Superclass {
+              beforeModel() {
+                this.router.transitionTo(
+                  "/discourse-ai/ai-bot/conversations"
+                );
+              }
+            }
+        );
       }
     });
   },

--- a/javascripts/discourse/initializers/init-force-homepage.js
+++ b/javascripts/discourse/initializers/init-force-homepage.js
@@ -10,9 +10,7 @@ export default {
           (Superclass) =>
             class extends Superclass {
               beforeModel() {
-                this.router.transitionTo(
-                  "/discourse-ai/ai-bot/conversations"
-                );
+                this.router.transitionTo("/discourse-ai/ai-bot/conversations");
               }
             }
         );


### PR DESCRIPTION
We had to revert a core commit, https://github.com/discourse/discourse/commit/a53910e606031747a13e14337be4541ecb0789f6, because it added a call to `discovery.${defaultHomepage()}` — which in the case of this theme caused `discourse-ai/ai-bot/conversations` to become `discovery.discourse-ai/ai-bot/conversations` 

The solution used here in the theme was kind of a hack anyway, so moving to `modifyClass` overrides the method and avoids this issue, as well as a previous issue with a circular reference. Ideally at some point we can update core to allow for arbitrary routes as the homepage and remove this override. 

So after merging this, we can go back and re-apply that core change. 

I also hid the "back to forum" button in the CSS, which is irrelevant here. 