### PR TITLE
Update link to sent messages in admin menu

### DIFF
--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -47,7 +47,7 @@ const CustomAdminMenu = <template>
             </LinkTo>
           </li>
           <li>
-            <a href="/u/discoursehelper/messages">
+            <a href="/u/discoursehelper/messages/sent">
               <span>
                 {{icon "envelope"}}
                 {{i18n (themePrefix "admin_menu.all_messages")}}


### PR DESCRIPTION
With https://github.com/discourse/discourse/pull/39891 the bot PMs are not showing by default but if you add /sent it shows all sent messages