### PR TITLE
UX: Show the `send_shortcut` preference on the interface preferences page

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -215,8 +215,13 @@ html.composer-open .custom-homepage #main-outlet {
     display: none;
   }
 
-  .control-group.home,
-  .control-group.other {
+  .control-group.home {
+    display: none;
+  }
+
+  // "Other settings" is hidden, apart from the send shortcut preference which
+  // controls how messages are submitted in the chat-style AI composer
+  .control-group.other > *:not(.pref-send-shortcut) {
     display: none;
   }
 }

--- a/spec/system/interface_preferences_spec.rb
+++ b/spec/system/interface_preferences_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe "Interface preferences", type: :system do
+  fab!(:current_user, :user)
+
+  let(:interface_preferences) { PageObjects::Pages::UserPreferencesInterface.new }
+
+  before do
+    upload_theme_or_component
+    sign_in(current_user)
+  end
+
+  it "shows the send shortcut preference while hiding the rest of the other settings group" do
+    interface_preferences.visit(current_user)
+
+    expect(page).to have_css(".control-group.other .pref-send-shortcut")
+    expect(page).to have_no_css(".control-group.other .pref-enable-quoting")
+    expect(page).to have_no_css(".control-group.home")
+  end
+end


### PR DESCRIPTION
**Previously**, the theme hid the entire `.control-group.other` group on the interface preferences page, so the new core `send_shortcut` user option was unreachable even though it controls the theme's chat-style AI composer.

**In this update**, that group reveals only the send shortcut preference, keeping the rest hidden, with a system spec covering it.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse-ask-theme/releases/download/_gh-attach-assets/before.png) | ![after](https://github.com/discourse/discourse-ask-theme/releases/download/_gh-attach-assets/after.png) |