### PR TITLE
UX: show some more user preferences

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -215,13 +215,9 @@ html.composer-open .custom-homepage #main-outlet {
     display: none;
   }
 
-  .control-group.home {
-    display: none;
-  }
-
-  // "Other settings" is hidden, apart from the send shortcut preference which
-  // controls how messages are submitted in the chat-style AI composer
-  .control-group.other > *:not(.pref-send-shortcut) {
+  .pref-auto-unpin,
+  .control-group.home,
+  .pref-new-user-tips {
     display: none;
   }
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -22,7 +22,7 @@ en:
   user_menu:
     feedback: "Support & Feedback"
     all_questions: "All Questions"
-    appearance: "Fonts & Appearance"
+    appearance: "Appearance & Preferences"
     account: "Account Settings"
   meta:
     profile_link: "on Meta"

--- a/spec/system/interface_preferences_spec.rb
+++ b/spec/system/interface_preferences_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Interface preferences", type: :system do
     interface_preferences.visit(current_user)
 
     expect(page).to have_css(".control-group.other .pref-send-shortcut")
-    expect(page).to have_no_css(".control-group.other .pref-enable-quoting")
     expect(page).to have_no_css(".control-group.home")
   end
 end


### PR DESCRIPTION
Displays some more useful user preferences that were once hidden

before
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/23bbe2e5-07bf-474f-9195-3ee94578af6e" />


after
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/3a1f3220-f96c-42ae-a978-7a1adcacbf93" />
