### PR TITLE
FEATURE: Add Admin Helper Messages link to the admin gear menu

### DIFF
--- a/javascripts/discourse/components/custom-admin-menu.gjs
+++ b/javascripts/discourse/components/custom-admin-menu.gjs
@@ -55,6 +55,16 @@ const CustomAdminMenu = <template>
             </a>
           </li>
           <li>
+            <a
+              href="/search?expanded=true&q=Admin%20Assistant%20chat%20with%20in:title%20personal_messages:discoursehelper%20order:latest"
+            >
+              <span>
+                {{icon "robot"}}
+                {{i18n (themePrefix "admin_menu.helper_messages")}}
+              </span>
+            </a>
+          </li>
+          <li>
             <a href="/admin/plugins/discourse-ai/ai-llms">
               <span>
                 {{icon "discourse-sparkles"}}{{i18n

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,7 @@ en:
   new_question: "New Question"
   admin_menu:
     all_messages: "All Bot Messages"
+    helper_messages: "Admin Helper Messages"
     ai_config: "AI Configuration"
     mod_messages: "Moderation Inbox"
     liked_messages: "Liked Messages"


### PR DESCRIPTION
Adds an **Admin Helper Messages** item to the gear (admin) header menu, below "All Bot Messages".

It opens full-page search pre-filtered to the `discoursehelper` bot's PM **titles** matching "Admin Assistant chat with", newest first:

`/search?expanded=true&q=Admin Assistant chat with in:title personal_messages:discoursehelper order:latest`

Notes:
- The link is relative (`/search?...`) rather than hard-coding `https://ask.discourse.com`, matching the other items in this menu and keeping SPA navigation/staging compatibility.
- `personal_messages:username` is an admin-only search filter server-side, which fits this admin-gated menu.
- Icon is `robot` (already in core's default sprite subset, no about.json registration needed).
- `pnpm lint` passes.